### PR TITLE
Add QtCore namespace to dependent namespaces with QtGui.

### DIFF
--- a/QtSharp/QtSharp.cs
+++ b/QtSharp/QtSharp.cs
@@ -178,6 +178,10 @@ namespace QtSharp
                 driver.Options.CodeFiles.Add(Path.Combine(dir, "DynamicQObject.cs"));
                 driver.Options.CodeFiles.Add(Path.Combine(dir, "MarshalQString.cs"));
 		    }
+            if (this.module == "Gui")
+            {
+                driver.Options.DependentNameSpaces.Add("QtCore");
+            }
 		}
 
 		public void SetupPasses(Driver driver)


### PR DESCRIPTION
Just an ad hoc thing to do, but recently I started to review the errors that are in the generated QtGui.cs. This fixes the first of them, placing the "using QtCore;" directive to the start of the file.
