### PR TITLE
Add a functions to copy QtCore-inlines.dll to Tests and add an unsafe keyword to compile.

### DIFF
--- a/QtSharp.CLI/Program.cs
+++ b/QtSharp.CLI/Program.cs
@@ -78,6 +78,14 @@ namespace QtSharp.CLI
                     ConsoleDriver.Run(new QtSharp(qmake, make, headers, libs, libFile, target, systemIncludeDirs, docs));
                 }
             }
+
+#if DEBUG
+			System.IO.File.Delete("../../../QtSharp.Tests/bin/Debug/QtCore-inlines.dll");
+			System.IO.File.Copy("release/QtCore-inlines.dll", "../../../QtSharp.Tests/bin/Debug/QtCore-inlines.dll");
+#else
+			System.IO.File.Delete("../../../QtSharp.Tests/bin/Release/QtCore-inlines.dll");
+			System.IO.File.Copy("release/QtCore-inlines.dll", "../../../QtSharp.Tests/bin/Release/QtCore-inlines.dll");
+#endif
             return 0;
         }
 

--- a/QtSharp.Tests/QtSharp.Tests.csproj
+++ b/QtSharp.Tests/QtSharp.Tests.csproj
@@ -32,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />


### PR DESCRIPTION
Add a functions to copy QtCore-inlines.dll to Tests.
Add an unsafe keyword to compile.