### PR TITLE
Add more structure to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,33 @@ QtSharp
 
 Mono/.NET bindings for Qt
 
-This project aims to create Mono/.NET libraries that wrap Qt (https://qt-project.org/) thus enabling its usage through C#. It relies on the excellent CppSharp (https://github.com/mono/CppSharp).
-It is a generator that expects the include and library directories of a Qt set-up and then generates and compiles the wrappers. While still in development, it should work with any Qt version when complete. There is no Qt included in the repository, users have to download and install Qt themselves. For now, Qt MinGW for Windows has been the only tested version. Qt for OS X and Linux are planned, Qt for VC++ has not been planned for now.
+This project aims to create Mono/.NET libraries that wrap Qt (https://qt-project.org/) thus enabling its usage through C#.
+It relies on the excellent CppSharp (https://github.com/mono/CppSharp).
+It is a generator that expects the include and library directories of a Qt set-up and then generates and compiles the wrappers.
+While still in development, it should work with any Qt version when complete.
+There is no Qt included in the repository, users have to download and install Qt themselves.
+For now, Qt MinGW for Windows has been the only tested version.
+Qt for OS X and Linux are planned, Qt for VC++ has not been planned for now.
 
-The source code is separated into a library that contains the settings and passes the generator needs, and a command-line client. In the future a GUI client, constructed with Qt# itself, is planned as well.
+The source code is separated into a library that contains the settings and passes the generator needs, and a command-line client.
+In the future a GUI client, constructed with Qt# itself, is planned as well.
 
 When the generated bindings are stable, binary releases will be uploaded.
 
+## Documentation
+
+1. [Building - QtSharp](https://github.com/ddobrev/QtSharp/blob/master/Docs/1.%20Building%20-%20QtSharp.md)
+2. [Running - QTSharp CLI](https://github.com/ddobrev/QtSharp/blob/master/Docs/2.%20Running%20-%20QtSharp.CLI.md)
+3. [Running - NUnit Tests](https://github.com/ddobrev/QtSharp/blob/master/Docs/3.%20Running%20-%20NUnit%20Tests.md)
+4. [Building - CppSharp](https://github.com/ddobrev/QtSharp/blob/master/Docs/4.%20Building%20-%20CppSharp.md)
+
+## Coverage
 
 QtSharp has been tested only with Qt for MinGW, and with Qt's built-in MinGW set-up, so far.
 
+## Funding
 
-In order to speed up the development of the project, I've been looking for funding. There are 2 ways for that. The first one is sponsoring Qt# itself. The second way would be paid assignments related to CppSharp - for example bindings for other C++ libraries. Either way is going to immensely benefit Qt#.
+In order to speed up the development of the project, I've been looking for funding.
+There are 2 ways for that. The first one is sponsoring Qt# itself.
+The second way would be paid assignments related to CppSharp - for example bindings for other C++ libraries.
+Either way is going to immensely benefit Qt#.


### PR DESCRIPTION
I would recommend for you to use a new line per sentence in README.md because markdown does treat them as if [they were in the same line](https://github.com/txdv/QtSharp). Also it allows for easier comparison using the diff tools between sentences and what changed in them - when something changes you always only the changed sentence, git also is able to represent what words in that sentence changed. Also, reading it with a simple editor is easier that way ... at least for my taste.

I also added the documentation files in the README, because I feel this should be a resource available immediately when you open the README file.