### PR TITLE
Fixes to ProcessHelper

### DIFF
--- a/QtSharp.CLI/Program.cs
+++ b/QtSharp.CLI/Program.cs
@@ -129,7 +129,7 @@ namespace QtSharp.CLI
 
             string emptyFile = Platform.IsWindows ? "NUL" : "/dev/null";
             string output;
-            ProcessHelper.Run("gcc", string.Format("-v -E -x c++ {0}", emptyFile), out output, waitForExit: !Platform.IsWindows);
+            ProcessHelper.Run("gcc", string.Format("-v -E -x c++ {0}", emptyFile), out output);
             qt.Target = Regex.Match(output, @"Target:\s*(?<target>[^\r\n]+)").Groups["target"].Value;
 
             const string includeDirsRegex = @"#include <\.\.\.> search starts here:(?<includes>.+)End of search list";


### PR DESCRIPTION
I spotted the problem listed here recently when trying to run QtSharp.CLI
https://bugreports.qt.io/browse/QTBUG-55951

I noticed that the ProcessHelper class seems to hang on process.WaitForExit() when there's a problem with the called process (this has something to do with the redirection of stdout / stderr)

so I made a change to it to fix that
also the output from stdout / stderr should now be visible on the console to see what's going on

Note process.WaitForExit(); is called regardless of the state of the waitForExit parameter since otherwise there's not enough time to get the standard output / standard error result for calls that need this result.
