### PR TITLE
Update 2. Running - QtSharp.CLI.md

### DIFF
--- a/Docs/2. Running - QtSharp.CLI.md
+++ b/Docs/2. Running - QtSharp.CLI.md
@@ -24,6 +24,38 @@ The other alternative is just to
 
 This should create a packages subdirectory and download any needed external libraries
 
+## Edit Qt(Qt4.8)
+When you use Qt 4.8, you need to edit Qt.
+Qt4.8 has two bugs. To avoid bugs, you edit Qt headers.
+
+### qtmultimediadefs.h
+
+You edit line 1.
+
+```
+#include "../../src/multimedia/qtmultimediadefs.h"
+```
+
+->
+
+```
+// #include "../../src/multimedia/qtmultimediadefs.h"
+```
+
+### qopenglversionfunctions.h
+
+You edit line 130.
+
+```
+    void init()
+```
+
+->
+
+```
+    void init() {}
+```
+
 ## Building QtSharp / QtSharp.CLI
 
 ### Visual Studio 2013


### PR DESCRIPTION
When bindings for Qt 4.8 is generated, Qt's headers must be edited to avoid bugs.
I added how to edit.